### PR TITLE
ENH: Gridsearch more (#3)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,8 @@ awscli = "*"
 pandas = "*"
 scikit-learn = "==0.20.0"
 sagemaker-containers = "*"
+matplotlib = "*"
+seaborn = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e42abe64e0785c6b018a1a26eb9ec9cb995ffdc2e9b188c3714a9433752d5f80"
+            "sha256": "38cd5909284d54c773c6f89fd41a0e1e2a7eaa4ecd1aa02242b21d4c80e95c6b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,18 +26,18 @@
         },
         "asn1crypto": {
             "hashes": [
-                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
-                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+                "sha256:0b199f211ae690df3db4fd6c1c4ff976497fb1da689193e368eedbadc53d9292",
+                "sha256:bca90060bd995c3f62c4433168eab407e44bdbdb567b3f3a396a676c1a4c4a3f"
             ],
-            "version": "==0.24.0"
+            "version": "==1.0.1"
         },
         "awscli": {
             "hashes": [
-                "sha256:6894c73bafc041f3bef883c731bcc7bb0fe7ff277f9d766efa37249bfc2001d4",
-                "sha256:f992907fb4d2072df7ab92faa7e369dda989709295800fe47376fa4ac818162a"
+                "sha256:2b8f94678edb213914dd2238b10bc4b4a325d66957bdfce7522c0f0520979d97",
+                "sha256:94a4d73f4b0b5d096675930df503ff1a513bc52e968fb29e25da00b481ef1aef"
             ],
             "index": "pypi",
-            "version": "==1.16.249"
+            "version": "==1.16.256"
         },
         "backcall": {
             "hashes": [
@@ -69,18 +69,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:5ff78c697d8009b9fe9808baea60660f0a07be666fb7c65fc4c11756f568124e",
-                "sha256:d01314496080ac82ddff3d1b2c6ad542d89bfcb100b7a0e8aaf2d6aef99775c6"
+                "sha256:9a84be232ff6432312c16b8e52cc5a01e6ff461cb9b50b3cafee24c6876a5012",
+                "sha256:ad269aa51439e0dd5f8245913bd2dd85684e37c237f5635143e96d48ce74f0eb"
             ],
             "index": "pypi",
-            "version": "==1.9.239"
+            "version": "==1.9.246"
         },
         "botocore": {
             "hashes": [
-                "sha256:14ff881779776a5b08e4bb8d7e0cd6ca86e36fc80decc536d605c406fb81c993",
-                "sha256:5df4a8f8bb579daed58368d6c15cdd72455bfee7dc86be243e2ef4dff5ba1177"
+                "sha256:210d9de193e1a1f8ad22ce57b6c18d48c79ff0c093680ec1a07e83a635fce4c7",
+                "sha256:6dcc121be4917cc731577a2ddff67b89cee6a4b0ec30241ce207a80a0d41990a"
             ],
-            "version": "==1.12.239"
+            "version": "==1.12.246"
         },
         "cffi": {
             "hashes": [
@@ -124,10 +124,11 @@
         },
         "colorama": {
             "hashes": [
-                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
-                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
             ],
-            "version": "==0.3.9"
+            "markers": "python_version != '2.6' and python_version != '3.3'",
+            "version": "==0.4.1"
         },
         "cryptography": {
             "hashes": [
@@ -149,6 +150,13 @@
                 "sha256:f57b76e46a58b63d1c6375017f4564a28f19a5ca912691fd2e4261b3414b618d"
             ],
             "version": "==2.7"
+        },
+        "cycler": {
+            "hashes": [
+                "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d",
+                "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
+            ],
+            "version": "==0.10.0"
         },
         "decorator": {
             "hashes": [
@@ -276,10 +284,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
-                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
+                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
             ],
-            "version": "==2.10.1"
+            "version": "==2.10.3"
         },
         "jmespath": {
             "hashes": [
@@ -290,17 +298,50 @@
         },
         "jupyter-client": {
             "hashes": [
-                "sha256:6a6d415c62179728f6d9295b37356d8f6833e9e01c2b6e1901dc555571f57b21",
-                "sha256:f406f214f9daa92be110d5b83d62f3451ffc73d3522db7350f0554683533ab18"
+                "sha256:60e6faec1031d63df57f1cc671ed673dced0ed420f4377ea33db37b1c188b910",
+                "sha256:d0c077c9aaa4432ad485e7733e4d91e48f87b4f4bab7d283d42bb24cbbba0a0f"
             ],
-            "version": "==5.3.3"
+            "version": "==5.3.4"
         },
         "jupyter-core": {
             "hashes": [
-                "sha256:2c6e7c1e9f2ac45b5c2ceea5730bc9008d92fe59d0725eac57b04c0edfba24f7",
-                "sha256:f4fa22d6cf25f34807c995f22d2923693575c70f02557bcbfbe59bd5ec8d8b84"
+                "sha256:1368a838bba378c3c99f54c2961489831ea929ec7689a1d59d9844e584bc27dc",
+                "sha256:85103cee6548992780912c1a0a9ec2583a4a18f1ef79a248ec0db4446500bce3"
             ],
-            "version": "==4.5.0"
+            "version": "==4.6.0"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:05b5b061e09f60f56244adc885c4a7867da25ca387376b02c1efc29cc16bcd0f",
+                "sha256:26f4fbd6f5e1dabff70a9ba0d2c4bd30761086454aa30dddc5b52764ee4852b7",
+                "sha256:3b2378ad387f49cbb328205bda569b9f87288d6bc1bf4cd683c34523a2341efe",
+                "sha256:400599c0fe58d21522cae0e8b22318e09d9729451b17ee61ba8e1e7c0346565c",
+                "sha256:47b8cb81a7d18dbaf4fed6a61c3cecdb5adec7b4ac292bddb0d016d57e8507d5",
+                "sha256:53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75",
+                "sha256:58e626e1f7dfbb620d08d457325a4cdac65d1809680009f46bf41eaf74ad0187",
+                "sha256:5a52e1b006bfa5be04fe4debbcdd2688432a9af4b207a3f429c74ad625022641",
+                "sha256:5c7ca4e449ac9f99b3b9d4693debb1d6d237d1542dd6a56b3305fe8a9620f883",
+                "sha256:682e54f0ce8f45981878756d7203fd01e188cc6c8b2c5e2cf03675390b4534d5",
+                "sha256:79bfb2f0bd7cbf9ea256612c9523367e5ec51d7cd616ae20ca2c90f575d839a2",
+                "sha256:7f4dd50874177d2bb060d74769210f3bce1af87a8c7cf5b37d032ebf94f0aca3",
+                "sha256:8944a16020c07b682df861207b7e0efcd2f46c7488619cb55f65882279119389",
+                "sha256:8aa7009437640beb2768bfd06da049bad0df85f47ff18426261acecd1cf00897",
+                "sha256:939f36f21a8c571686eb491acfffa9c7f1ac345087281b412d63ea39ca14ec4a",
+                "sha256:9733b7f64bd9f807832d673355f79703f81f0b3e52bfce420fc00d8cb28c6a6c",
+                "sha256:a02f6c3e229d0b7220bd74600e9351e18bc0c361b05f29adae0d10599ae0e326",
+                "sha256:a0c0a9f06872330d0dd31b45607197caab3c22777600e88031bfe66799e70bb0",
+                "sha256:acc4df99308111585121db217681f1ce0eecb48d3a828a2f9bbf9773f4937e9e",
+                "sha256:b64916959e4ae0ac78af7c3e8cef4becee0c0e9694ad477b4c6b3a536de6a544",
+                "sha256:d3fcf0819dc3fea58be1fd1ca390851bdb719a549850e708ed858503ff25d995",
+                "sha256:d52e3b1868a4e8fd18b5cb15055c76820df514e26aa84cc02f593d99fef6707f",
+                "sha256:db1a5d3cc4ae943d674718d6c47d2d82488ddd94b93b9e12d24aabdbfe48caee",
+                "sha256:e3a21a720791712ed721c7b95d433e036134de6f18c77dbe96119eaf7aa08004",
+                "sha256:e8bf074363ce2babeb4764d94f8e65efd22e6a7c74860a4f05a6947afc020ff2",
+                "sha256:f16814a4a96dc04bf1da7d53ee8d5b1d6decfc1a92a63349bb15d37b6a263dd9",
+                "sha256:f2b22153870ca5cf2ab9c940d7bc38e8e9089fa0f7e5856ea195e1cf4ff43d5a",
+                "sha256:f790f8b3dff3d53453de6a7b7ddd173d2e020fb160baff578d578065b108a05f"
+            ],
+            "version": "==1.1.0"
         },
         "markupsafe": {
             "hashes": [
@@ -334,6 +375,21 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
             "version": "==1.1.1"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:1febd22afe1489b13c6749ea059d392c03261b2950d1d45c17e3aed812080c93",
+                "sha256:31a30d03f39528c79f3a592857be62a08595dec4ac034978ecd0f814fa0eec2d",
+                "sha256:4442ce720907f67a79d45de9ada47be81ce17e6c2f448b3c64765af93f6829c9",
+                "sha256:796edbd1182cbffa7e1e7a97f1e141f875a8501ba8dd834269ae3cd45a8c976f",
+                "sha256:934e6243df7165aad097572abf5b6003c77c9b6c480c3c4de6f2ef1b5fdd4ec0",
+                "sha256:bab9d848dbf1517bc58d1f486772e99919b19efef5dd8596d4b26f9f5ee08b6b",
+                "sha256:c1fe1e6cdaa53f11f088b7470c2056c0df7d80ee4858dadf6cbe433fcba4323b",
+                "sha256:e5b8aeca9276a3a988caebe9f08366ed519fff98f77c6df5b64d7603d0e42e36",
+                "sha256:ec6bd0a6a58df3628ff269978f4a4b924a0d371ad8ce1f8e2b635b99e482877a"
+            ],
+            "index": "pypi",
+            "version": "==3.1.1"
         },
         "nltk": {
             "hashes": [
@@ -415,11 +471,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780",
-                "sha256:2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1",
-                "sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55"
+                "sha256:46642344ce457641f28fc9d1c9ca939b63dadf8df128b86f1b9860e59c73a5e4",
+                "sha256:e7f8af9e3d70f514373bf41aa51bc33af12a6db3f71461ea47fea985defb2c31",
+                "sha256:f15af68f66e664eaa559d4ac8a928111eebd5feda0c11738b5998045224829db"
             ],
-            "version": "==2.0.9"
+            "version": "==2.0.10"
         },
         "psutil": {
             "hashes": [
@@ -451,8 +507,7 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3",
-                "sha256:e02fe4290d7685ea4a9463693aaba38211c69fead5010bde80c2b62535497444"
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
             ],
             "version": "==2.19"
         },
@@ -487,6 +542,13 @@
             ],
             "version": "==1.3.0"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+            ],
+            "version": "==2.4.2"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
@@ -497,10 +559,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
-                "sha256:c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
             ],
-            "version": "==2019.2"
+            "version": "==2019.3"
         },
         "pyyaml": {
             "hashes": [
@@ -633,6 +695,14 @@
             ],
             "version": "==1.3.1"
         },
+        "seaborn": {
+            "hashes": [
+                "sha256:42e627b24e849c2d3bbfd059e00005f6afbc4a76e4895baf44ae23fe8a4b09a5",
+                "sha256:76c83f794ca320fb6b23a7c6192d5e185a5fcf4758966a0c0a54baee46d41e2f"
+            ],
+            "index": "pypi",
+            "version": "==0.9.0"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
@@ -661,10 +731,10 @@
         },
         "traitlets": {
             "hashes": [
-                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
-                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
+                "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44",
+                "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"
             ],
-            "version": "==4.3.2"
+            "version": "==4.3.3"
         },
         "typing": {
             "hashes": [

--- a/Upload Training Data to S3.ipynb
+++ b/Upload Training Data to S3.ipynb
@@ -7,8 +7,8 @@
     "# Upload Training Data to s3\n",
     "This notebook assumes:\n",
     " - You've got all of the labeled solicitaton documents within a directory named `labeled_fbo_docs`.\n",
-    " - You can use the `awscli` and have configured it.\n",
-    " - You have already created an S3 bucket (our is named `srt-sm`)."
+    " - You can use the `awscli` and have configured it. See [this](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) for instructions. We recommend placing the credentials in a shared credential file (`~/.aws/credentials`)\n",
+    " - You have already created an S3 bucket (ours is named `srt-sm`)."
    ]
   },
   {
@@ -17,45 +17,9 @@
    "source": [
     "## Read in the training data\n",
     "\n",
-    "Below, we'll read in 50 of the nearly $1,000$ documents and extract the text along with the label (the label is in the file name). \n",
+    "Below, we'll read in the labeled documents and extract the text along with the label (the label is in the file name). \n",
     "\n",
     ">Although there are three lables (red, yellow and green), we're combining red and yellow as noncompliant ($0$) and treating green as compliant ($1$). This makes a binary classification challenge."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import random\n",
-    "\n",
-    "data = []\n",
-    "for i, file in enumerate(os.listdir('labeled_fbo_docs')):\n",
-    "    if i < 50:\n",
-    "        if file.startswith('GREEN'):\n",
-    "            target = 1\n",
-    "        elif file.startswith('RED') or file.startswith('YELLOW'):\n",
-    "            target = 0\n",
-    "        else:\n",
-    "            raise Exception(f\"A file isn't prepended with the target:  {file}\")\n",
-    "\n",
-    "        file_path = os.path.join(os.getcwd(), 'labeled_fbo_docs', file)\n",
-    "        with open(file_path, 'r', errors = 'ignore') as f:\n",
-    "            #do some newline replacing\n",
-    "            text = f.read().replace(\"\\n\", ' ').strip()\n",
-    "        data.append([target, text])\n",
-    "    else:\n",
-    "        break"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Split the samples into training and test datasets\n",
-    "Since our data is imbalanced, we'll use the `stratify` kwarg to split the data in a stratified fashion, using the labels array."
    ]
   },
   {
@@ -67,8 +31,51 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "25.00% of the training data is a positive sample\n",
-      "20.00% of the testing data is a positive sample\n"
+      "Done reading in 993 documents.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import random\n",
+    "\n",
+    "data = []\n",
+    "for file in os.listdir('labeled_fbo_docs'):\n",
+    "    if file.startswith('GREEN'):\n",
+    "        target = 1\n",
+    "    elif file.startswith('RED') or file.startswith('YELLOW'):\n",
+    "        target = 0\n",
+    "    else:\n",
+    "        raise Exception(f\"A file isn't prepended with the target:  {file}\")\n",
+    "\n",
+    "    file_path = os.path.join(os.getcwd(), 'labeled_fbo_docs', file)\n",
+    "    with open(file_path, 'r', errors = 'ignore') as f:\n",
+    "        #do some newline replacing\n",
+    "        text = f.read().replace(\"\\n\", ' ').strip()\n",
+    "    data.append([target, text])\n",
+    "    \n",
+    "print(f\"Done reading in {len(data)} documents.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Split the samples into training and test datasets\n",
+    "Since our data is imbalanced, we'll use the `stratify` method to split the data in a balanced fashion, using the labels array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "27.33% of the training data is a positive sample\n",
+      "27.14% of the testing data is a positive sample\n"
      ]
     }
    ],
@@ -98,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,12 +131,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we'll read in the files we wrote just to make sure we do it correctly in our sagemaker scripts."
+    "Here we'll read in the files we wrote just to make sure we do it correctly in our sagemaker notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -161,27 +168,27 @@
        "    <tr>\n",
        "      <td>0</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>This is a combined synopsis/solicitation for c...</td>\n",
+       "      <td>OBJECTIVE    The RRB seeks electronic data sto...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>General Information:   Document Type:         ...</td>\n",
+       "      <td>Checklist and Certification for Minimum Level ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>2</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>Attachment 1                         Glossary ...</td>\n",
+       "      <td>Date Issued:  January 6, 2009 Date Due:  Febru...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>3</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>STATEMENT OF WORK     (SOW)    FOR    317 RCS/...</td>\n",
+       "      <td>Section SF 1449 - CONTINUATION SHEET    |ITEM ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>4</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>|SOLICITATION, OFFER AND AWARD                ...</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>Statement of Work                             ...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -189,14 +196,14 @@
       ],
       "text/plain": [
        "   target                                               text\n",
-       "0     0.0  This is a combined synopsis/solicitation for c...\n",
-       "1     0.0  General Information:   Document Type:         ...\n",
-       "2     1.0  Attachment 1                         Glossary ...\n",
-       "3     0.0  STATEMENT OF WORK     (SOW)    FOR    317 RCS/...\n",
-       "4     0.0  |SOLICITATION, OFFER AND AWARD                ..."
+       "0     0.0  OBJECTIVE    The RRB seeks electronic data sto...\n",
+       "1     0.0  Checklist and Certification for Minimum Level ...\n",
+       "2     1.0  Date Issued:  January 6, 2009 Date Due:  Febru...\n",
+       "3     0.0  Section SF 1449 - CONTINUATION SHEET    |ITEM ...\n",
+       "4     1.0  Statement of Work                             ..."
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -221,15 +228,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Done writing to s3n://srt-sm/Scikit-LinearLearner-pipeline-srt/srt_train.csv\n",
-      "Done writing to s3n://srt-sm/Scikit-LinearLearner-pipeline-srt/srt_test.csv\n"
+      "Done writing to s3n://srt-sm/Sklearn-RandomizedGridSearch/srt_train.csv\n",
+      "Done writing to s3n://srt-sm/Sklearn-RandomizedGridSearch/srt_test.csv\n"
      ]
     }
    ],
@@ -239,7 +246,7 @@
     "s3 = boto3.resource('s3')\n",
     "region = boto3.Session().region_name\n",
     "bucket = 'srt-sm' \n",
-    "prefix = 'Scikit-LinearLearner-pipeline-srt'\n",
+    "prefix = 'Sklearn-RandomizedGridSearch'\n",
     "bucket_path = f'https://s3-{region}.amazonaws.com/{bucket}'\n",
     "\n",
     "for f in ['srt_train.csv', 'srt_test.csv']:\n",
@@ -248,6 +255,13 @@
     "    url = f's3n://{bucket}/{key}'\n",
     "    print(f'Done writing to {url}')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/pipeline/featurizers.py
+++ b/pipeline/featurizers.py
@@ -58,7 +58,7 @@ class TextPreprocessor(BaseEstimator, TransformerMixin):
                               'it', 'how', 'further', 'was', 'here', 'than'}
 
 
-        def fit(self, X, y = None):
+        def fit(self, X, y=None):
             return self 
         
         def _keep_token(self, token):
@@ -88,7 +88,7 @@ class TextPreprocessor(BaseEstimator, TransformerMixin):
                 if not pos_tag:
                     lemmas.append(self.wnl.lemmatize(token).lower())
                     continue
-                lemmas.append(self.wnl.lemmatize(token, pos = pos_tag).lower())
+                lemmas.append(self.wnl.lemmatize(token, pos=pos_tag).lower())
              
             return " ".join(lemmas)
                 

--- a/pipeline/train.py
+++ b/pipeline/train.py
@@ -4,38 +4,36 @@ from sklearn import metrics
 from sklearn.model_selection import train_test_split, RandomizedSearchCV
 
 
-class log_uniform():        
+class log_uniform():
+    """Provides an instance of a log-uniform distribution with an rvs method for use in
+    hyperparameter grid. The low param is intuitively the number of decimal places to which
+    the left end of the distrubution will go (e.g. lowe=-5 means the min value might be 1.1e-05).
+    High is the number of decimals to which the right end of the distrubution will go (e.g.
+    high=3 means the max might be 999.2). The resultant log-uniform distribution will be skewed
+    right, with the majority of values being < 1.
     """
-    Provides an instance of the log-uniform distribution with an .rvs() method. 
-    Meant to be used with RandomizedSearchCV, particularly for params like alpha/C/gamma.
-    
-    Attributes:
-        a (int or float): the exponent of the beginning of the range 
-        b (int or float): the exponent of the end of range. 
-        base (int or float): the base of the logarithm. 10 by default.
-    """
-    
-    def __init__(self, a=-1, b=0, base=10):
-        self.loc = a
-        self.scale = b - a
+    def __init__(self, low=-5, high=3, base=10):
+        self.low = low
+        self.scale = high
         self.base = base
 
-    def rvs(self, size=1, random_state=None):
-        uniform = stats.uniform(loc=self.loc, scale=self.scale)
-        return np.power(self.base, uniform.rvs(size=size, random_state=random_state))
+    def rvs(self,):
+        return np.power(self.base, np.random.uniform(self.low, self.high))
 
 
-def randomized_grid_search(df, pipeline, objective_metric_name='roc_auc', n_iter_search=5):
-    """
-    Performs a randomized grid search `n_iter_search` times using the pipeline provided and 
-    the `objective_metric_name` as a scoring metric during refittig.
+def randomized_grid_search(df, pipeline, objective_metric_name='roc_auc', n_iter_search=1):
+    """Randomized grid search of a pipeline of transformers using objective_metric_name as the scorer.
     
-    Attributes:
-        df (pandas DataFrame):  the training data
-        pipeline (sklearn Pipeline object): a pipeline of transformers, ending in an estimator 
-        objective_metric_name (str): the scorer used to evaluate the predictions on the test set. `roc_auc` by
-                      default. Available options include:  accuracy, roc_auc, precision, fbeta, recall.
-                      Note: for fbeta, beta is set to 1.5 to favor recall of the positive class.
+    Arguments:
+        df {pandas.DataFrame} -- a data frame with at least a 'text' and 'target' column
+        pipeline {sklearn.Pipeline} -- a pipeline of sklearn transformers accepting text as the input
+    
+    Keyword Arguments:
+        objective_metric_name {str} -- the scorer to use for refitting (default: {'roc_auc'})
+        n_iter_search {int} -- how many grid search iterations (default: {1})
+    
+    Returns:
+        [type] -- [description]
     """
     scoring = {'accuracy': metrics.make_scorer(metrics.accuracy_score),
                'roc_auc': metrics.make_scorer(metrics.roc_auc_score),
@@ -51,25 +49,27 @@ def randomized_grid_search(df, pipeline, objective_metric_name='roc_auc', n_iter
                                                         test_size=0.2)
     hyperparam_grid = {
                        "vectorizer__ngram_range": [(1,1), (1,2)],
-                       "vectorizer__min_df": stats.randint(1,3),
-                       "vectorizer__max_df": stats.uniform(.95,.3),
+                       "vectorizer__max_df": stats.uniform(.8,.95),
                        "vectorizer__sublinear_tf": [True, False],
-                       "select__n_components": stats.randint(10,50),
-                       "select__n_iter": stats.randint(5,10),
+                       "select__n_components": stats.randint(100,200),
+                       "select__n_iter": stats.randint(5,20),
                        "estimator__alpha": log_uniform(-5,2),
                        "estimator__penalty": ['l2','l1','elasticnet'],
-                       "estimator__max_iter": stats.randint(5,10),
-                       "estimator__loss": ['hinge', 'log', 'modified_huber', 'squared_hinge', 'perceptron'],
+                       "estimator__max_iter": stats.randint(10,50),
+                       "estimator__learning_rate": ['invscaling', 'constant', 'optimal'],
+                       "estimator__eta0": log_uniform(-3,0),
+                       "estimator__power_t": log_uniform(-4,0),
+                       "estimator__loss": ['hinge', 'log', 'modified_huber', 'squared_hinge', 'perceptron']
                        }
     
     random_search = RandomizedSearchCV(pipeline, 
-                                       param_distributions = hyperparam_grid, 
-                                       scoring = scoring, 
-                                       refit = objective_metric_name,
-                                       n_iter = n_iter_search, 
-                                       cv = 5,
-                                       n_jobs = -1, 
-                                       verbose = 1)
+                                       param_distributions=hyperparam_grid, 
+                                       scoring=scoring, 
+                                       refit=objective_metric_name,
+                                       n_iter=n_iter_search, 
+                                       cv=5,
+                                       n_jobs=-1, 
+                                       verbose=1)
     
     random_search.fit(X_train, y_train)
     best_estimator = random_search.best_estimator_

--- a/srt.ipynb
+++ b/srt.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Create SageMaker session and role"
+    "# Create SageMaker session and role\n",
+    "\n",
+    "Here my make use of the execution role we gave the sagemaker notebook instance. This role provides access to the S3 bucket we created. "
    ]
   },
   {
@@ -15,7 +17,9 @@
    "source": [
     "# S3 prefix\n",
     "s3_bucket = 'srt-sm'\n",
-    "prefix = 'Scikit-LinearLearner-pipeline-srt'\n",
+    "\n",
+    "#prefix = 'Scikit-LinearLearner-pipeline-srt' #use this for a smaller subset of the training data\n",
+    "prefix = 'Scikit-RandomizedGridSearch' #this is all 993 labeled samples\n",
     "\n",
     "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
@@ -31,14 +35,14 @@
    "metadata": {},
    "source": [
     "# Create a SageMaker Scikit estimator \n",
-    "To run our Scikit-learn training script on SageMaker, we construct a `sagemaker.sklearn.estimator.sklearn` estimator, which accepts several constructor arguments:\n",
+    "Here we create an insance of a `sagemaker.sklearn.estimator.sklearn` estimator. The constructor accepts several constructor arguments:\n",
     "\n",
-    " - **source_dir**: Path (absolute or relative) to a directory with any other training source code dependencies aside from tne entry point file (default: None). Structure within this directory are preserved when training on Amazon SageMaker.\n",
-    " - **entry_point**: The path to the Python script SageMaker runs for training and prediction.\n",
-    " - **role**: Role ARN\n",
-    " - **train_instance_type (optional)**: The type of SageMaker instances for training. Note: Because Scikit-learn does not natively support GPU training, Sagemaker Scikit-learn does not currently support training on GPU instance types.\n",
-    " - **sagemaker_session (optional)**: The session used to train on Sagemaker.\n",
-    " - **output_path (optional)**: s3 location where you want the training result (model artifacts and optional output files) saved. If not specified, results are stored to a default bucket. If the bucket with the specific name does not exist, the estimator creates the bucket during the fit() method execution.\n",
+    " - **source_dir**: Path (absolute or relative) to the directory with our custom model training source code.\n",
+    " - **entry_point**: The path to the Python script SageMaker runs for training and prediction within `source_dir`.\n",
+    " - **role**: Role ARN, which is provided by `get_execution_role()`\n",
+    " - **train_instance_type (optional)**: The type of SageMaker instances for training. Note: Because Scikit-learn does not natively support GPU training, Sagemaker Scikit-learn does not currently support training on GPU instance types. Also, note that you may need to request an EC2 quota increase for these ml ec2 instance types.\n",
+    " - **sagemaker_session (optional)**: The session used to train on Sagemaker, as returned by `sagemaker.Session()`.\n",
+    " - **output_path (optional)**: s3 location where you want the training result (model artifacts and optional output files) saved. If not specified, results are stored to a default bucket. If the bucket with the specific name does not exist, the estimator creates the bucket during execution of the `fit()` method.\n",
     " "
    ]
   },
@@ -59,7 +63,7 @@
     "grid_search = SKLearn(source_dir = source_dir,\n",
     "                      entry_point = entry_point,\n",
     "                      role = role,\n",
-    "                      train_instance_type = \"ml.c4.xlarge\",\n",
+    "                      train_instance_type = \"ml.c5.4xlarge\",\n",
     "                      sagemaker_session = sagemaker_session,\n",
     "                      output_path = model_output_path)\n",
     "\n",
@@ -87,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we've got a fitted model (i.e. the best estimator from the Grid Search), we'll deploy this model behind a single endpoint."
+    "We now have a fitted model (i.e. the best estimator from the Grid Search) in our s3 bucket. We can now deploy this model behind a single endpoint. When this is done, you'll be able to see this endpoint under **Endpoints** in the SageMaker console."
    ]
   },
   {
@@ -116,10 +120,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Make a request to the endpoint \n",
-    "Here we'll use the deployed model to get predictions for our test data. \n",
+    "# Request inferences from the endpoint \n",
+    "With our model deployed behind a REST API, we'll now make some requests to it in order to get inferences from our validation set. We can then use these inferences to see how well the trained model performs on out-of-sample data.\n",
     "\n",
-    "We need to make our request with the payload in `text/csv` format, since that is what our script currently supports (see `input_fn()` in our entrypoin). If other formats need to be supported, this would have to be added to the our entrypoint. Note that we set the `accept` to `application/json` to get our output, i.e. the inferences, that way."
+    "Note that we need to make our request with the payload in `text/csv` format, since that is what our script currently supports (see `input_fn()` in our entrypoint file). If other formats need to be supported, this would have to be added to that `input_fn()` function. Note, however, that we set the `accept` to `application/json` to get our output, i.e. the inferences, that way. We do this because our `ouput_fn()` function returns JSON."
    ]
   },
   {
@@ -132,8 +136,10 @@
     "from sagemaker.predictor import json_serializer, csv_serializer, json_deserializer, RealTimePredictor\n",
     "from sagemaker.content_types import CONTENT_TYPE_CSV, CONTENT_TYPE_JSON\n",
     "\n",
+    "#read in the validation set from the s3 bucket\n",
     "test_input = f's3://{s3_bucket}/{prefix}/srt_test.csv'\n",
     "\n",
+    "#convert it to a pandas dataframe\n",
     "test_df = pd.read_csv(test_input)\n",
     "\n",
     "def format_as_csv(text):\n",
@@ -149,8 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
-    "\n",
+    "# create an instance of RealTimePredictor, which simplifies sending the requests\n",
     "predictor = RealTimePredictor(endpoint = endpoint_name,\n",
     "                              sagemaker_session = sagemaker_session,\n",
     "                              serializer = csv_serializer,\n",
@@ -164,12 +169,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
+    "\n",
     "# request an inference for a single sample\n",
     "sample = test_df['1'].iloc[0]\n",
     "\n",
     "prediction_str = predictor.predict(sample)\n",
-    "prediction_dict = json.loads(prediction_str)\n",
-    "prediction_dict"
+    "print(prediction_str)"
    ]
   },
   {
@@ -178,11 +184,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# request inferences for multiple samples\n",
+    "# request inferences for all of the samples in the validation set\n",
     "samples = test_df['1'].tolist()\n",
     "predictions_str = predictor.predict(samples)\n",
     "predictions_dict = json.loads(predictions_str)\n",
     "predictions_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluate model performance on the validation set"
    ]
   },
   {
@@ -199,6 +212,17 @@
     "from sklearn.metrics import accuracy_score\n",
     "\n",
     "accuracy_score(y_true, y_pred)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import classification_report\n",
+    "\n",
+    "clf_report = classification_report(y_true, y_pred)"
    ]
   },
   {


### PR DESCRIPTION
- Use a larger EC2 instance for model training
- Push all training data to s3 bucket, using a different prefix for the objects
- Simplify usage of log_uniform
- Add more hyperparamters to grid search
- Increase number of iterations for grid search
- Improve annotations in `srt.ipynb`